### PR TITLE
Fix: Move undefined window check to inside of return.

### DIFF
--- a/Worker.js
+++ b/Worker.js
@@ -1,7 +1,5 @@
-if (typeof window === 'undefined') return;
-
 (function(window) {
-  if (typeof window.Worker !== 'undefined') return;
+  if (typeof window === 'undefined' || typeof window.Worker !== 'undefined') return;
   if (console && console.log) console.log('!! Using web worker fallback');
 
   var WW_CONTEXT_WHITELIST = [


### PR DESCRIPTION
Reason: Parse error in ES5 when ran in global scope because you cannot use return outside of a function.
